### PR TITLE
Fixes for warnings using the stable toolchain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,25 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    # Service containers to run with `runner-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,6 +56,16 @@ jobs:
             libxcb-render-util0-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev
+
+      - name: Configure environment for CI postgres
+        run: |
+          echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
+        env:
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+
+      - name: Run migrations on CI postgres
+        run: |
+          cargo run --bin migrator
 
       - name: Clippy
         run: cargo clippy --all-targets --verbose -- -D warnings

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,8 +2,15 @@
 name = "cosmicverge"
 version = "0.1.0"
 authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
-edition = "2018"
+description = "The game client for Cosmic Verge"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
 publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
 
 [dependencies]
 kludgine = { git = "https://github.com/khonsulabs/kludgine.git", branch = "main", default-features = false, features = ["tokio-rt", "bundled-fonts"] }

--- a/client/src/cache/image.rs
+++ b/client/src/cache/image.rs
@@ -33,11 +33,11 @@ impl Image {
         } else {
             let resource = CachedResource::new(&source_url).await?;
 
-            Ok(tracker.track(source_url, move || Image::from(resource)))
+            Ok(tracker.track(source_url, move || Self::from(resource)))
         }
     }
 
-    fn cache() -> &'static Handle<Tracker<Image>> {
+    fn cache() -> &'static Handle<Tracker<Self>> {
         CACHE_WORKERS_INITIALIZED.get_or_init(|| Handle::new(Tracker::default()))
     }
 

--- a/client/src/cluster_admin/cluster_map.rs
+++ b/client/src/cluster_admin/cluster_map.rs
@@ -12,9 +12,6 @@ pub struct ClusterMap {
     hovered: Option<MapLayoutEntity>,
 }
 
-#[derive(Debug, Clone)]
-pub enum Command {}
-
 #[async_trait]
 impl Component for ClusterMap {
     async fn update(&mut self, context: &mut Context) -> KludgineResult<()> {
@@ -126,7 +123,7 @@ impl Component for ClusterMap {
 #[async_trait]
 impl InteractiveComponent for ClusterMap {
     type Message = ();
-    type Command = Command;
+    type Command = ();
     type Event = ();
 }
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -16,8 +16,6 @@
     // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
-    // Clippy is bugged
-    clippy::use_self
 )]
 
 mod api;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -13,7 +13,7 @@
     clippy::cast_precision_loss,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
+    // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
     // Clippy is bugged

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -2,8 +2,15 @@
 name = "database"
 version = "0.1.0"
 authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
-edition = "2018"
+description = "Database access layer for cosmicverge-server"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
 publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
 
 [dependencies]
 cosmicverge-shared = { path = "../shared" }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -18,7 +18,6 @@
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
     // Clippy is bugged
-    clippy::use_self,
     clippy::similar_names, // This is not buggy on nightly, so it should be re-checked. affect sql::query!() false positives
     // Clippy is super bugged
     clippy::used_underscore_binding
@@ -50,11 +49,11 @@ impl From<sqlx::Error> for DatabaseError {
                 .map(|c| c == "23505")
                 .unwrap_or_default()
             {
-                return DatabaseError::Conflict;
+                return Self::Conflict;
             }
         }
 
-        DatabaseError::Other(error)
+        Self::Other(error)
     }
 }
 

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -14,11 +14,12 @@
     clippy::cast_sign_loss,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
+    // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
     // Clippy is bugged
     clippy::use_self,
+    clippy::similar_names, // This is not buggy on nightly, so it should be re-checked. affect sql::query!() false positives
     // Clippy is super bugged
     clippy::used_underscore_binding
 )]

--- a/database/src/schema/pilot.rs
+++ b/database/src/schema/pilot.rs
@@ -15,8 +15,8 @@ pub struct Pilot {
 }
 
 impl From<Pilot> for protocol::Pilot {
-    fn from(pilot: Pilot) -> protocol::Pilot {
-        protocol::Pilot {
+    fn from(pilot: Pilot) -> Self {
+        Self {
             id: pilot.id(),
             created_at: pilot.created_at,
             name: pilot.name,

--- a/migrations/Cargo.toml
+++ b/migrations/Cargo.toml
@@ -2,8 +2,15 @@
 name = "migrations"
 version = "0.0.1"
 authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
-edition = "2018"
+description = "PostgreSQL migrations for cosmicverge-server"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
 publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
 
 [lib]
 path = "src/lib.rs"

--- a/migrations/src/lib.rs
+++ b/migrations/src/lib.rs
@@ -16,8 +16,6 @@
     // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
-    // Clippy is bugged
-    clippy::use_self
 )]
 
 mod connection;

--- a/migrations/src/lib.rs
+++ b/migrations/src/lib.rs
@@ -13,7 +13,7 @@
     clippy::cast_precision_loss,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
+    // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
     // Clippy is bugged

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "cosmicverge-server"
 version = "0.1.0"
-authors = ["Jonathan Johnson <jon@nilobject.com>"]
-edition = "2018"
-build = "../build.rs"
+authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
+description = "The Cosmic Verge server"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
 publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
+build = "../build.rs"
 
 [dependencies]
 cosmicverge-shared = { path = "../shared", features = ["redis"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,8 +17,7 @@
     clippy::missing_errors_doc,
     // clippy::missing_panics_doc, // not on stable yet
     clippy::option_if_let_else,
-    // Clippy is bugged
-    clippy::use_self
+    
 )]
 
 #[macro_use]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,7 +15,7 @@
     clippy::cast_sign_loss,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
+    // clippy::missing_panics_doc, // not on stable yet
     clippy::option_if_let_else,
     // Clippy is bugged
     clippy::use_self

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,7 +17,6 @@
     clippy::missing_errors_doc,
     // clippy::missing_panics_doc, // not on stable yet
     clippy::option_if_let_else,
-    
 )]
 
 #[macro_use]

--- a/server/src/orchestrator/location_store.rs
+++ b/server/src/orchestrator/location_store.rs
@@ -20,7 +20,7 @@ static SHARED_STORE: OnceCell<LocationStore> = OnceCell::new();
 impl LocationStore {
     pub async fn initialize(redis: MultiplexedConnection) {
         if SHARED_STORE.get().is_none() {
-            let store = LocationStore {
+            let store = Self {
                 redis,
                 cache: Arc::new(RwLock::new(LocationCache::default())),
             };

--- a/server/src/planets.rs
+++ b/server/src/planets.rs
@@ -35,195 +35,57 @@ impl ObjectElevations {
     /// A basic elevation color palette that kinda resembles an earthlike planet
     pub fn earthlike() -> Vec<ElevationColor<Self>> {
         vec![
-            ElevationColor::from_u8(
-                ObjectElevations::DeepOcean,
-                19,
-                30,
-                180,
-                Kilometers::new(0.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::ShallowOcean,
-                98,
-                125,
-                223,
-                Kilometers::new(10.),
-            ),
-            ElevationColor::from_u8(ObjectElevations::Beach, 209, 207, 169, Kilometers::new(11.)),
-            ElevationColor::from_u8(ObjectElevations::Grass, 152, 214, 102, Kilometers::new(13.)),
-            ElevationColor::from_u8(ObjectElevations::Forest, 47, 106, 42, Kilometers::new(15.)),
-            ElevationColor::from_u8(
-                ObjectElevations::Mountain,
-                100,
-                73,
-                53,
-                Kilometers::new(18.),
-            ),
-            ElevationColor::from_u8(ObjectElevations::Snow, 238, 246, 245, Kilometers::new(20.)),
+            ElevationColor::from_u8(Self::DeepOcean, 19, 30, 180, Kilometers::new(0.)),
+            ElevationColor::from_u8(Self::ShallowOcean, 98, 125, 223, Kilometers::new(10.)),
+            ElevationColor::from_u8(Self::Beach, 209, 207, 169, Kilometers::new(11.)),
+            ElevationColor::from_u8(Self::Grass, 152, 214, 102, Kilometers::new(13.)),
+            ElevationColor::from_u8(Self::Forest, 47, 106, 42, Kilometers::new(15.)),
+            ElevationColor::from_u8(Self::Mountain, 100, 73, 53, Kilometers::new(18.)),
+            ElevationColor::from_u8(Self::Snow, 238, 246, 245, Kilometers::new(20.)),
         ]
     }
 
     pub fn redrock() -> Vec<ElevationColor<Self>> {
         vec![
-            ElevationColor::from_u8(
-                ObjectElevations::Canyon,
-                0x69,
-                0x1D,
-                0x1D,
-                Kilometers::new(0.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::Crater,
-                0x96,
-                0x48,
-                0x48,
-                Kilometers::new(1.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::Ground,
-                0xB8,
-                0x6F,
-                0x6F,
-                Kilometers::new(2.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::Mountain,
-                0x74,
-                0x20,
-                0x20,
-                Kilometers::new(3.),
-            ),
+            ElevationColor::from_u8(Self::Canyon, 0x69, 0x1D, 0x1D, Kilometers::new(0.)),
+            ElevationColor::from_u8(Self::Crater, 0x96, 0x48, 0x48, Kilometers::new(1.)),
+            ElevationColor::from_u8(Self::Ground, 0xB8, 0x6F, 0x6F, Kilometers::new(2.)),
+            ElevationColor::from_u8(Self::Mountain, 0x74, 0x20, 0x20, Kilometers::new(3.)),
         ]
     }
 
     pub fn whiterock() -> Vec<ElevationColor<Self>> {
         vec![
-            ElevationColor::from_u8(
-                ObjectElevations::Canyon,
-                0x9B,
-                0xA8,
-                0xA8,
-                Kilometers::new(0.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::Crater,
-                0xE9,
-                0xF6,
-                0xF6,
-                Kilometers::new(1.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::Ground,
-                0xCE,
-                0xDF,
-                0xDF,
-                Kilometers::new(2.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::Mountain,
-                0xAA,
-                0xB9,
-                0xB9,
-                Kilometers::new(3.),
-            ),
+            ElevationColor::from_u8(Self::Canyon, 0x9B, 0xA8, 0xA8, Kilometers::new(0.)),
+            ElevationColor::from_u8(Self::Crater, 0xE9, 0xF6, 0xF6, Kilometers::new(1.)),
+            ElevationColor::from_u8(Self::Ground, 0xCE, 0xDF, 0xDF, Kilometers::new(2.)),
+            ElevationColor::from_u8(Self::Mountain, 0xAA, 0xB9, 0xB9, Kilometers::new(3.)),
         ]
     }
 
     pub fn sunlike() -> Vec<ElevationColor<Self>> {
         vec![
             // Deep base glow
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeDeepBase,
-                189,
-                31,
-                10,
-                Kilometers::new(0.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeBase,
-                220,
-                94,
-                33,
-                Kilometers::new(1.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeMiddle,
-                235,
-                125,
-                45,
-                Kilometers::new(2.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeBrightMiddle,
-                250,
-                156,
-                56,
-                Kilometers::new(3.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeTop,
-                253,
-                187,
-                49,
-                Kilometers::new(4.),
-            ),
+            ElevationColor::from_u8(Self::SunlikeDeepBase, 189, 31, 10, Kilometers::new(0.)),
+            ElevationColor::from_u8(Self::SunlikeBase, 220, 94, 33, Kilometers::new(1.)),
+            ElevationColor::from_u8(Self::SunlikeMiddle, 235, 125, 45, Kilometers::new(2.)),
+            ElevationColor::from_u8(Self::SunlikeBrightMiddle, 250, 156, 56, Kilometers::new(3.)),
+            ElevationColor::from_u8(Self::SunlikeTop, 253, 187, 49, Kilometers::new(4.)),
             // Hot top
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeHotTop,
-                255,
-                218,
-                41,
-                Kilometers::new(5.),
-            ),
+            ElevationColor::from_u8(Self::SunlikeHotTop, 255, 218, 41, Kilometers::new(5.)),
         ]
     }
 
     pub fn blue_sunlike() -> Vec<ElevationColor<Self>> {
         vec![
             // Deep base glow
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeDeepBase,
-                10,
-                31,
-                189,
-                Kilometers::new(0.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeBase,
-                39,
-                110,
-                228,
-                Kilometers::new(1.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeMiddle,
-                45,
-                125,
-                235,
-                Kilometers::new(2.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeBrightMiddle,
-                56,
-                156,
-                250,
-                Kilometers::new(1.),
-            ),
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeTop,
-                49,
-                187,
-                253,
-                Kilometers::new(4.),
-            ),
+            ElevationColor::from_u8(Self::SunlikeDeepBase, 10, 31, 189, Kilometers::new(0.)),
+            ElevationColor::from_u8(Self::SunlikeBase, 39, 110, 228, Kilometers::new(1.)),
+            ElevationColor::from_u8(Self::SunlikeMiddle, 45, 125, 235, Kilometers::new(2.)),
+            ElevationColor::from_u8(Self::SunlikeBrightMiddle, 56, 156, 250, Kilometers::new(1.)),
+            ElevationColor::from_u8(Self::SunlikeTop, 49, 187, 253, Kilometers::new(4.)),
             // Hot top
-            ElevationColor::from_u8(
-                ObjectElevations::SunlikeHotTop,
-                41,
-                218,
-                255,
-                Kilometers::new(2.),
-            ),
+            ElevationColor::from_u8(Self::SunlikeHotTop, 41, 218, 255, Kilometers::new(2.)),
         ]
     }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "cosmicverge-shared"
 version = "0.0.1"
-authors = ["Jonathan Johnson <jon@nilobject.com>"]
-edition = "2018"
+authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
+description = "Code that is shared between the client and server of Cosmic Verge"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
 publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
+build = "../build.rs"
 
 [features]
 default = []

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -13,7 +13,7 @@
     clippy::cast_precision_loss,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
+    // clippy::missing_panics_doc, // not on stable yet
     clippy::option_if_let_else,
     // Clippy is bugged
     clippy::use_self

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -15,8 +15,6 @@
     clippy::missing_errors_doc,
     // clippy::missing_panics_doc, // not on stable yet
     clippy::option_if_let_else,
-    // Clippy is bugged
-    clippy::use_self
 )]
 
 //! Shared abstraction that will be re-used throughout the project.

--- a/shared/src/permissions.rs
+++ b/shared/src/permissions.rs
@@ -35,8 +35,8 @@ pub enum AccountPermission {
 impl Display for Permission {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (service, permission) = match self {
-            Permission::Account(perm) => (Service::Account, perm.to_string()),
-            Permission::Universe(perm) => (Service::Universe, perm.to_string()),
+            Self::Account(perm) => (Service::Account, perm.to_string()),
+            Self::Universe(perm) => (Service::Universe, perm.to_string()),
         };
         f.write_str(&service.to_string())?;
         f.write_char('(')?;
@@ -77,8 +77,8 @@ impl FromStr for Permission {
         let service = Service::from_str(&service)?;
 
         let permission = match service {
-            Service::Account => Permission::Account(AccountPermission::from_str(&permission)?),
-            Service::Universe => Permission::Universe(GenericPermission::from_str(&permission)?),
+            Service::Account => Self::Account(AccountPermission::from_str(&permission)?),
+            Service::Universe => Self::Universe(GenericPermission::from_str(&permission)?),
         };
 
         Ok(permission)
@@ -123,8 +123,8 @@ impl Service {
     #[must_use]
     pub fn permissions(&self) -> Vec<Permission> {
         match self {
-            Service::Account => AccountPermission::iter().map(Permission::Account).collect(),
-            Service::Universe => GenericPermission::iter()
+            Self::Account => AccountPermission::iter().map(Permission::Account).collect(),
+            Self::Universe => GenericPermission::iter()
                 .map(Permission::Universe)
                 .collect(),
         }
@@ -135,8 +135,8 @@ impl Permission {
     #[must_use]
     pub const fn service(self) -> Service {
         match self {
-            Permission::Account(_) => Service::Account,
-            Permission::Universe(_) => Service::Universe,
+            Self::Account(_) => Service::Account,
+            Self::Universe(_) => Service::Universe,
         }
     }
 }

--- a/shared/src/protocol/navigation/piloting.rs
+++ b/shared/src/protocol/navigation/piloting.rs
@@ -15,7 +15,7 @@ pub enum Action {
 
 impl Default for Action {
     fn default() -> Self {
-        Action::Idle
+        Self::Idle
     }
 }
 

--- a/shared/src/ships/mod.rs
+++ b/shared/src/ships/mod.rs
@@ -74,7 +74,7 @@ pub enum Id {
 impl Named for Id {
     fn name(&self) -> &'static str {
         match self {
-            Id::Shuttle => "Shuttle",
+            Self::Shuttle => "Shuttle",
         }
     }
 }

--- a/shared/src/solar_systems/sm0a9f4.rs
+++ b/shared/src/solar_systems/sm0a9f4.rs
@@ -13,9 +13,9 @@ pub enum SM0A9F4 {
 impl Named for SM0A9F4 {
     fn name(&self) -> &'static str {
         match self {
-            SM0A9F4::Sun => "Sun",
-            SM0A9F4::Earth => "Earth",
-            SM0A9F4::Mercury => "Mercury",
+            Self::Sun => "Sun",
+            Self::Earth => "Earth",
+            Self::Mercury => "Mercury",
         }
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "web"
 version = "0.1.0"
-authors = ["Jonathan Johnson <jon@nilobject.com>"]
-edition = "2018"
-build = "../build.rs"
+authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
+description = "The web-app for CosmicVerge.com"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
 publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
+build = "../build.rs"
 
 [lib]
 crate-type = ["cdylib"]

--- a/web/src/extended_text_metrics.rs
+++ b/web/src/extended_text_metrics.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_pass_by_value)] // False positive triggered by #[wasm_bindgen]
+
 use wasm_bindgen::{prelude::*, JsCast};
 
 #[wasm_bindgen]

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -15,7 +15,7 @@
     clippy::implicit_hasher,
     clippy::items_after_statements,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
+    // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
     // Clippy is bugged

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -18,8 +18,6 @@
     // clippy::missing_panics_doc, // not on stable yet
     clippy::multiple_crate_versions,
     clippy::option_if_let_else,
-    // Clippy is bugged
-    clippy::use_self,
     // TODO: fix clippy
     clippy::default_trait_access
 )]


### PR DESCRIPTION
We discovered that we were not using the same toolchain. Now that we are using rust-toolchain to pin ourselves to stable, we had a new set of warnings. This PR resolves all the warnings to give us a clean slate.