### PR TITLE
Add integration tests for the CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,6 +308,7 @@ jobs:
       - name: Configure environment for CI postgres
         run: |
           echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
+          echo "TEST_DATABASE_URL=$DATABASE_URL" >> .env
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,9 @@ jobs:
           ref: ${{ matrix.branch }}
       - name: Audit
         run: |
-          cargo audit -D warnings --ignore RUSTSEC-2020-0016
+          cargo audit -D warnings --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2020-0095
           echo '::warning::Ignoring alert for issue https://github.com/khonsulabs/kludgine/issues/47'
+          echo '::warning::Ignoring alert for unmaintained underlying dependency of assert_cmd, used only during testing https://github.com/johannhof/difference.rs/issues/45'
   format:
     runs-on: ubuntu-latest
 
@@ -147,6 +148,7 @@ jobs:
       - name: Configure environment for CI postgres
         run: |
           echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
+          echo "TEST_DATABASE_URL=$DATABASE_URL" >> .env
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 
@@ -195,6 +197,7 @@ jobs:
       - name: Configure environment for CI postgres
         run: |
           echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
+          echo "TEST_DATABASE_URL=$DATABASE_URL" >> .env
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 
@@ -308,7 +311,6 @@ jobs:
       - name: Configure environment for CI postgres
         run: |
           echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
-          echo "TEST_DATABASE_URL=$DATABASE_URL" >> .env
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Configure environment for CI postgres
         run: |
           echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
-          echo "TEST_DATABASE_URL=$DATABASE_URL" >> .env
+          echo "TEST_DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 
@@ -197,7 +197,7 @@ jobs:
       - name: Configure environment for CI postgres
         run: |
           echo "DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
-          echo "TEST_DATABASE_URL=$DATABASE_URL" >> .env
+          echo "TEST_DATABASE_URL=postgres://postgres:postgres@localhost:$POSTGRES_PORT/postgres" >> .env
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,14 +3560,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "54fd1046a3107eb58f42de31d656fee6853e5d276c455fd943742dce89fc3dd3"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -3582,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -4147,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-simple-migrator"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a46e8a1929e8f3ee6e0c2fbcc6a57b458e883beb5567481d27a6e0470052bc3"
+checksum = "2b4eed3df29391c9ee94af9f774225646dd8135b809493962e456175d68168cb"
 dependencies = [
  "sqlx",
  "thiserror",
@@ -5459,7 +5458,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "sqlx-simple-migrator"
-version = "0.0.5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,6 @@ dependencies = [
  "jsonwebtoken",
  "magrathea",
  "once_cell",
- "predicates",
  "redis",
  "reqwest",
  "serde",
@@ -2880,12 +2879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,10 +3270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
 dependencies = [
  "difference",
- "float-cmp",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2475b58cd94eb4f70159f4fd8844ba3b807532fe3131b3373fae060bbe30396"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +858,7 @@ name = "cosmicverge-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-channel",
  "async-trait",
  "chrono",
@@ -855,6 +870,7 @@ dependencies = [
  "jsonwebtoken",
  "magrathea",
  "once_cell",
+ "predicates",
  "redis",
  "reqwest",
  "serde",
@@ -1152,6 +1168,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -2858,6 +2880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,6 +3269,35 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -4536,6 +4593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4751,6 +4814,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"
@@ -5387,3 +5459,7 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "sqlx-simple-migrator"
+version = "0.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ opt-level = "s"
 # For tokio 1.0 compatibility
 # basws-server = { path = "../basws/basws-server" }
 # basws-shared = { path = "../basws/basws-shared" }
-sqlx-simple-migrator = { path = "../sqlx-simple-migrator" }
+# sqlx-simple-migrator = { path = "../sqlx-simple-migrator" }
 # magrathea = { path = "../magrathea" }
 # kludgine = { path = "../kludgine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ opt-level = "s"
 # For tokio 1.0 compatibility
 # basws-server = { path = "../basws/basws-server" }
 # basws-shared = { path = "../basws/basws-shared" }
-# sqlx-simple-migrator = { path = "../sqlx-simple-migrator" }
+sqlx-simple-migrator = { path = "../sqlx-simple-migrator" }
 # magrathea = { path = "../magrathea" }
 # kludgine = { path = "../kludgine" }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Once Redis is running, it needs no extra configuration. For Postgres, you need a
 ```sql
 CREATE ROLE cosmicuser LOGIN PASSWORD '***';
 CREATE DATABASE cosmicverge OWNER cosmicuser;
+CREATE DATABASE cosmicverge_test OWNER cosmicuser;
 ```
 
 ### Twitch OAuth
@@ -50,6 +51,7 @@ To configure your environment, place a file named `.env` in the root of the repo
 
 ```ini
 DATABASE_URL="postgres://cosmicuser:***@localhost/cosmicverge"
+TEST_DATABASE_URL="postgres://cosmicuser:***@localhost/cosmicverge_test"
 TWITCH_CLIENT_ID="***"
 TWITCH_CLIENT_SECRET="***"
 REDIS_URL="redis://localhost:6379"

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 
 [features]
 default = []
-test-util = []
+test-util = ["migrations/test-util"]
 
 [dependencies]
 cosmicverge-shared = { path = "../shared" }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -12,6 +12,10 @@ keywords = ["sandbox", "game"]
 categories = ["games"]
 readme = "../README.md"
 
+[features]
+default = []
+test-util = []
+
 [dependencies]
 cosmicverge-shared = { path = "../shared" }
 basws-server = "0.1"

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -71,6 +71,7 @@ impl<T> SqlxResultExt<T> for Result<T, sqlx::Error> {
     }
 }
 
+#[cfg(feature = "test-util")]
 pub mod test_util {
     use std::env;
 

--- a/database/src/schema/account.rs
+++ b/database/src/schema/account.rs
@@ -256,6 +256,12 @@ mod tests {
 
         TwitchProfile::delete("account_lookup_twitch_id", &mut tx).await?;
 
+        assert!(
+            Account::find_by_twitch_id("account_lookup_twitch_id", &mut tx)
+                .await?
+                .is_none()
+        );
+
         Ok(())
     }
 }

--- a/database/src/schema/account.rs
+++ b/database/src/schema/account.rs
@@ -113,8 +113,8 @@ impl Account {
 
     // Delete an account
     //
-    // Do expose this to be used outside of testing. When we support account deletion,
-    // there will be a process involved to ensure we're complying with
+    // Don't expose this to be used outside of testing. When we support account
+    // deletion, there will be a process involved to ensure we're complying with
     // international privacy laws.
     #[cfg(feature = "test-util")]
     pub async fn delete<'e, E: sqlx::Executor<'e, Database = sqlx::Postgres>>(

--- a/database/src/schema/account.rs
+++ b/database/src/schema/account.rs
@@ -111,6 +111,21 @@ impl Account {
         .map(|_| ())
     }
 
+    // Delete an account
+    //
+    // Do not use this outside of testing. When we support account deletion,
+    // there will be a process involved to ensure we're complying with
+    // international privacy laws.
+    pub async fn delete<'e, E: sqlx::Executor<'e, Database = sqlx::Postgres>>(
+        &self,
+        executor: E,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query!("DELETE FROM accounts WHERE id = $1", self.id,)
+            .execute(executor)
+            .await
+            .map(|_| ())
+    }
+
     pub async fn permissions<'e, E: sqlx::Executor<'e, Database = sqlx::Postgres>>(
         &self,
         executor: E,
@@ -170,12 +185,14 @@ mod tests {
     use super::*;
     use crate::{
         schema::{PermissionGroup, TwitchProfile},
-        test_util::pool,
+        test_util::initialize_safe_test,
     };
+    use migrations::pool;
 
     #[tokio::test]
-    async fn account_permissions() -> sqlx::Result<()> {
-        let mut tx = pool().await.begin().await?;
+    async fn account_permissions() -> anyhow::Result<()> {
+        initialize_safe_test().await;
+        let mut tx = pool().begin().await?;
         let account = Account::create(&mut tx).await?;
         let permissions = account.permissions(&mut tx).await?;
         assert_eq!(permissions, Permissions::PermissionSet(HashSet::new()));
@@ -199,13 +216,13 @@ mod tests {
         ]));
         assert!(permissions.has_permission(Permission::Account(AccountPermission::View)));
         assert!(!permissions.has_permission(Permission::Account(AccountPermission::List)));
-
         Ok(())
     }
 
     #[tokio::test]
-    async fn account_lookup() -> sqlx::Result<()> {
-        let mut tx = pool().await.begin().await?;
+    async fn account_lookup() -> anyhow::Result<()> {
+        initialize_safe_test().await;
+        let mut tx = pool().begin().await?;
         let account = Account::create(&mut tx).await?;
         assert_eq!(
             account.id,

--- a/database/src/schema/account.rs
+++ b/database/src/schema/account.rs
@@ -113,9 +113,10 @@ impl Account {
 
     // Delete an account
     //
-    // Do not use this outside of testing. When we support account deletion,
+    // Do expose this to be used outside of testing. When we support account deletion,
     // there will be a process involved to ensure we're complying with
     // international privacy laws.
+    #[cfg(feature = "test-util")]
     pub async fn delete<'e, E: sqlx::Executor<'e, Database = sqlx::Postgres>>(
         &self,
         executor: E,
@@ -252,6 +253,8 @@ mod tests {
                 .unwrap()
                 .id
         );
+
+        TwitchProfile::delete("account_lookup_twitch_id", &mut tx).await?;
 
         Ok(())
     }

--- a/database/src/schema/permission_group.rs
+++ b/database/src/schema/permission_group.rs
@@ -180,6 +180,12 @@ async fn create_lookup_delete_test() -> anyhow::Result<()> {
 
     group.delete(&mut tx).await?;
 
+    assert!(
+        PermissionGroup::find_by_name("create_and_lookup_test", &mut tx)
+            .await
+            .is_err()
+    );
+
     Ok(())
 }
 

--- a/database/src/schema/permission_group.rs
+++ b/database/src/schema/permission_group.rs
@@ -171,7 +171,7 @@ mod tests {
     use migrations::pool;
 
     #[tokio::test]
-    async fn create_and_lookup() -> anyhow::Result<()> {
+    async fn create_lookup_delete() -> anyhow::Result<()> {
         initialize_safe_test().await;
 
         let mut tx = pool().begin().await?;
@@ -183,6 +183,9 @@ mod tests {
                 .await?
                 .id
         );
+
+        group.delete(&mut tx).await?;
+
         Ok(())
     }
 

--- a/database/src/schema/permission_group.rs
+++ b/database/src/schema/permission_group.rs
@@ -164,34 +164,27 @@ impl Statement {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_util::initialize_safe_test;
-    use migrations::pool;
+#[tokio::test]
+async fn create_lookup_delete_test() -> anyhow::Result<()> {
+    crate::test_util::initialize_safe_test().await;
 
-    #[tokio::test]
-    async fn create_lookup_delete() -> anyhow::Result<()> {
-        initialize_safe_test().await;
+    let mut tx = migrations::pool().begin().await?;
+    let group = PermissionGroup::create("create_and_lookup_test", &mut tx).await?;
 
-        let mut tx = pool().begin().await?;
-        let group = PermissionGroup::create("create_and_lookup_test", &mut tx).await?;
+    assert_eq!(
+        group.id,
+        PermissionGroup::find_by_name("create_and_lookup_test", &mut tx)
+            .await?
+            .id
+    );
 
-        assert_eq!(
-            group.id,
-            PermissionGroup::find_by_name("create_and_lookup_test", &mut tx)
-                .await?
-                .id
-        );
+    group.delete(&mut tx).await?;
 
-        group.delete(&mut tx).await?;
+    Ok(())
+}
 
-        Ok(())
-    }
-
-    #[test]
-    fn test_display_permission() {
-        assert_eq!("*", &display_permission(&None));
-        assert_eq!("value", &display_permission(&Some(String::from("value"))));
-    }
+#[test]
+fn display_permission_test() {
+    assert_eq!("*", &display_permission(&None));
+    assert_eq!("value", &display_permission(&Some(String::from("value"))));
 }

--- a/database/src/schema/twitch_profile.rs
+++ b/database/src/schema/twitch_profile.rs
@@ -15,4 +15,13 @@ impl TwitchProfile {
             username,
         ).execute(executor).await.map(|_| ())
     }
+    pub async fn delete<'e, E: sqlx::Executor<'e, Database = sqlx::Postgres>>(
+        twitch_id: &str,
+        executor: E,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query!("DELETE FROM twitch_profiles WHERE id = $1", twitch_id,)
+            .execute(executor)
+            .await
+            .map(|_| ())
+    }
 }

--- a/migrations/Cargo.toml
+++ b/migrations/Cargo.toml
@@ -20,7 +20,7 @@ name = "migrator"
 path = "src/main.rs"
 
 [dependencies]
-sqlx-simple-migrator = "0.0.4"
+sqlx-simple-migrator = "0.0.5"
 once_cell = "1"
 tokio = { version = "1.0", features = ["full"] }
 dotenv = "0.15"

--- a/migrations/Cargo.toml
+++ b/migrations/Cargo.toml
@@ -12,6 +12,10 @@ keywords = ["sandbox", "game"]
 categories = ["games"]
 readme = "../README.md"
 
+[features]
+default = []
+test-util = []
+
 [lib]
 path = "src/lib.rs"
 

--- a/migrations/src/connection.rs
+++ b/migrations/src/connection.rs
@@ -10,11 +10,13 @@ pub fn pool() -> &'static PgPool {
     POOL.get().expect("uninitialized pool access")
 }
 
-pub async fn initialize() {
+pub async fn initialize(url: Option<String>) {
     if POOL.get().is_none() {
-        let pool = PgPool::connect(&env::var("DATABASE_URL").expect("DATABASE_URL not set"))
-            .await
-            .expect("Error initializing postgres pool");
+        let pool = PgPool::connect(
+            &url.unwrap_or_else(|| env::var("DATABASE_URL").expect("DATABASE_URL not set")),
+        )
+        .await
+        .expect("Error initializing postgres pool");
         POOL.set(pool).unwrap();
     }
 }

--- a/migrations/src/lib.rs
+++ b/migrations/src/lib.rs
@@ -22,7 +22,10 @@ mod connection;
 
 pub use connection::{initialize, pool};
 mod migrations;
-pub use self::migrations::{run_all, undo_all};
+pub use self::migrations::run_all;
+
+#[cfg(feature = "test-util")]
+pub use self::migrations::undo_all;
 
 pub use sqlx;
 pub use sqlx_simple_migrator::Migration;

--- a/migrations/src/lib.rs
+++ b/migrations/src/lib.rs
@@ -21,6 +21,8 @@
 mod connection;
 
 pub use connection::{initialize, pool};
-pub mod migrations;
+mod migrations;
+pub use self::migrations::{run_all, undo_all};
 
 pub use sqlx;
+pub use sqlx_simple_migrator::Migration;

--- a/migrations/src/main.rs
+++ b/migrations/src/main.rs
@@ -1,5 +1,4 @@
 mod connection;
-#[allow(dead_code)] // this mod exposes functions in lib.rs, but appears unused in the exe
 mod migrations;
 
 #[tokio::main]

--- a/migrations/src/main.rs
+++ b/migrations/src/main.rs
@@ -1,9 +1,10 @@
 mod connection;
+#[allow(dead_code)] // this mod exposes functions in lib.rs, but appears unused in the exe
 mod migrations;
 
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().unwrap();
-    connection::initialize().await;
+    connection::initialize(None).await;
     migrations::run_all().await.unwrap();
 }

--- a/migrations/src/main.rs
+++ b/migrations/src/main.rs
@@ -1,4 +1,10 @@
 mod connection;
+
+// cargo warns about code like `migrations::undo_all` not being used when
+// compiling this binary. The warning is incorrect, however, because this module
+// is public when consuming this as a lib. We could mark this mod as pub, but it
+// "feels" more correct to ignore the warning in this binary.
+#[allow(dead_code)]
 mod migrations;
 
 #[tokio::main]

--- a/migrations/src/migrations.rs
+++ b/migrations/src/migrations.rs
@@ -19,6 +19,7 @@ pub async fn run_all() -> Result<(), MigrationError> {
     Migration::run_all(pool(), migrations()).await
 }
 
+#[cfg(feature = "test-util")]
 pub async fn undo_all() -> Result<(), MigrationError> {
     Migration::undo_all(pool(), migrations()).await
 }

--- a/migrations/src/migrations.rs
+++ b/migrations/src/migrations.rs
@@ -7,7 +7,7 @@ mod migration_0002_pilots;
 mod migration_0003_permissions;
 
 #[must_use]
-pub fn migrations() -> Vec<Migration> {
+fn migrations() -> Vec<Migration> {
     vec![
         migration_0001_accounts::migration(),
         migration_0002_pilots::migration(),
@@ -17,4 +17,8 @@ pub fn migrations() -> Vec<Migration> {
 
 pub async fn run_all() -> Result<(), MigrationError> {
     Migration::run_all(pool(), migrations()).await
+}
+
+pub async fn undo_all() -> Result<(), MigrationError> {
+    Migration::undo_all(pool(), migrations()).await
 }

--- a/migrations/src/migrations/migration_0001_accounts.rs
+++ b/migrations/src/migrations/migration_0001_accounts.rs
@@ -22,6 +22,11 @@ pub fn migration() -> Migration {
             )
         "#,
         )
+        .with_down(
+            r#"
+            DROP TABLE IF EXISTS installations
+        "#,
+        )
         .with_up(
             r#"
             CREATE TABLE oauth_tokens (

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,3 +48,4 @@ cli-table = "0.4"
 
 [dev-dependencies]
 assert_cmd = "1"
+database = { path = "../database", features = ["test-util"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -45,3 +45,7 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 structopt = "0.3"
 magrathea = { version = "0.0.3" }
 cli-table = "0.4"
+
+[dev-dependencies]
+assert_cmd = "1"
+predicates = "1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,4 +48,3 @@ cli-table = "0.4"
 
 [dev-dependencies]
 assert_cmd = "1"
-predicates = "1"

--- a/server/src/cli/accounts.rs
+++ b/server/src/cli/accounts.rs
@@ -32,9 +32,9 @@ enum Operation {
 impl Command {
     pub async fn execute(self, database_url: Option<String>) -> anyhow::Result<()> {
         database::initialize(database_url).await;
-        let account = if let Some(id) = command.id {
+        let account = if let Some(id) = self.id {
             Account::load(id, database::pool()).await?
-        } else if let Some(twitch) = &command.twitch {
+        } else if let Some(twitch) = &self.twitch {
             Account::find_by_twitch_username(twitch, database::pool()).await?
         } else {
             anyhow::bail!("Either id or twitch parameters must be specified for account commands")

--- a/server/src/cli/accounts.rs
+++ b/server/src/cli/accounts.rs
@@ -30,11 +30,11 @@ enum Operation {
 }
 
 impl Command {
-    pub async fn execute(self) -> anyhow::Result<()> {
-        database::initialize().await;
-        let account = if let Some(id) = self.id {
+    pub async fn execute(self, database_url: Option<String>) -> anyhow::Result<()> {
+        database::initialize(database_url).await;
+        let account = if let Some(id) = command.id {
             Account::load(id, database::pool()).await?
-        } else if let Some(twitch) = &self.twitch {
+        } else if let Some(twitch) = &command.twitch {
             Account::find_by_twitch_username(twitch, database::pool()).await?
         } else {
             anyhow::bail!("Either id or twitch parameters must be specified for account commands")

--- a/server/src/cli/permission_groups.rs
+++ b/server/src/cli/permission_groups.rs
@@ -31,8 +31,8 @@ enum Operation {
 }
 
 impl Command {
-    pub async fn execute(self) -> anyhow::Result<()> {
-        database::initialize().await;
+    pub async fn execute(self, database_url: Option<String>) -> anyhow::Result<()> {
+        database::initialize(database_url).await;
 
         let group = match self.operation {
             Operation::Create => PermissionGroup::create(self.group_name, database::pool()).await?,

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -45,11 +45,11 @@ pub fn webserver_base_url() -> warp::http::uri::Builder {
         .authority("cosmicverge.com")
 }
 
-pub async fn run_webserver() -> anyhow::Result<()> {
+pub async fn run_webserver(database_url: Option<String>) -> anyhow::Result<()> {
     info!("server starting up - rev {}", current_git_revision!());
 
     info!("connecting to database");
-    database::initialize().await;
+    database::initialize(database_url).await;
     database::migrations::run_all()
         .await
         .expect("Error running migrations");

--- a/server/tests/accounts-cli.rs
+++ b/server/tests/accounts-cli.rs
@@ -1,0 +1,81 @@
+use assert_cmd::prelude::*;
+use database::schema::{Account, TwitchProfile};
+use std::{env, process::Command};
+
+#[tokio::test]
+async fn account_superuser_command() -> anyhow::Result<()> {
+    database::test_util::initialize_exclusive_test().await;
+
+    let account = Account::create(database::pool()).await?;
+    TwitchProfile::associate(
+        "fake_twitch_id",
+        account.id,
+        "twitch_username",
+        database::pool(),
+    )
+    .await?;
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("account")
+        .arg("--id")
+        .arg(account.id.to_string())
+        .arg("set-super-user")
+        .assert()
+        .success();
+    assert!(
+        Account::load(account.id, database::pool())
+            .await?
+            .unwrap()
+            .superuser
+    );
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("account")
+        .arg("--id")
+        .arg(account.id.to_string())
+        .arg("set-normal-user")
+        .assert()
+        .success();
+    assert!(
+        !Account::load(account.id, database::pool())
+            .await?
+            .unwrap()
+            .superuser
+    );
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("account")
+        .arg("--twitch")
+        .arg("Twitch_Username") // testing case insensitivity
+        .arg("set-super-user")
+        .assert()
+        .success();
+
+    assert!(
+        Account::load(account.id, database::pool())
+            .await?
+            .unwrap()
+            .superuser
+    );
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("account")
+        .arg("--twitch")
+        .arg("invalid_username") // testing case insensitivity
+        .arg("set-super-user")
+        .assert()
+        .failure();
+
+    TwitchProfile::delete("fake_twitch_id", database::pool()).await?;
+    account.delete(database::pool()).await?;
+
+    Ok(())
+}

--- a/server/tests/permission-groups-cli.rs
+++ b/server/tests/permission-groups-cli.rs
@@ -1,0 +1,80 @@
+use assert_cmd::prelude::*;
+use cosmicverge_shared::permissions::{AccountPermission, Permission, Service};
+use database::schema::{PermissionGroup, Statement};
+use std::{env, process::Command, str::FromStr};
+
+#[tokio::test]
+async fn permission_groups() -> anyhow::Result<()> {
+    database::test_util::initialize_exclusive_test().await;
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("permission-group")
+        .arg("test-group")
+        .arg("create")
+        .assert()
+        .success();
+
+    let group = PermissionGroup::find_by_name("test-group", database::pool()).await?;
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("permission-group")
+        .arg("test-group")
+        .arg("add")
+        .arg(Permission::Account(AccountPermission::TemporaryBan).to_string())
+        .assert()
+        .success();
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("permission-group")
+        .arg("test-group")
+        .arg("add-service")
+        .arg(Service::Universe.to_string())
+        .assert()
+        .success();
+
+    let statements = Statement::list_for_group_id(group.id, database::pool()).await?;
+    assert_eq!(2, statements.len());
+    assert!(statements.iter().any(|s| matches!(
+        s.permission
+            .as_ref()
+            .map(|p| Permission::from_str(p).ok())
+            .flatten(),
+        Some(Permission::Account(AccountPermission::TemporaryBan))
+    )));
+    assert!(statements.iter().any(|s| s.permission.is_none()
+        && matches!(Service::from_str(&s.service), Ok(Service::Universe))));
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("permission-group")
+        .arg("test-group")
+        .arg("remove")
+        .arg(Permission::Account(AccountPermission::TemporaryBan).to_string())
+        .assert()
+        .success();
+
+    Command::cargo_bin("cosmicverge-server")?
+        .arg("--database-url")
+        .arg(env::var("TEST_DATABASE_URL")?)
+        .arg("permission-group")
+        .arg("test-group")
+        .arg("remove-service")
+        .arg(Service::Universe.to_string())
+        .assert()
+        .success();
+
+    assert!(Statement::list_for_group_id(group.id, database::pool())
+        .await?
+        .is_empty());
+
+    group.delete(database::pool()).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This change refactors how database tests are run. There are two
initialization methods that return a lock guard that controls the flow
of other database tests. Safe tests are written using a transaction to
isolate all of the database calls, and are therefore safe to run
simultaneously as other safe tests. Unsafe tests are written in a way
that they try to clean themselves up, but the test environment will
automatically clear the database before each unsafe test.

The last change is that tests are now run in their own database, and
during the first database test's initialization, all migrations are
unwound and then performed to give the database a clean slate.

These tests mean that the database migrations themselves are now run as
part of the test harness, which is another added bonus.

As an added bonus, while testing this feature, I realized that we both missed that the Remove permission select statement was coded to add the permission (fixed in the other PR). Clearly, it is beneficial to have end-to-end tests.