### PR TITLE
Add persistent logging service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,6 +215,7 @@ jobs:
           zip -0 ccov.zip `find . \( -name "cosmicverge_shared-*.gc*" \) -print`
           zip -0 ccov.zip `find . \( -name "cosmicverge_server-*.gc*" \) -print`
           zip -0 ccov.zip `find . \( -name "cosmicverge-*.gc*" \) -print`
+          zip -0 ccov.zip `find . \( -name "logger-*.gc*" \) -print`
           zip -0 ccov.zip `find . \( -name "database-*.gc*" \) -print`
           zip -0 ccov.zip `find . \( -name "migrations-*.gc*" \) -print`
           zip -0 ccov.zip `find . \( -name "web-*.gc*" \) -print`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
 [[package]]
 name = "kludgine"
 version = "0.0.2"
+source = "git+https://github.com/khonsulabs/kludgine.git?branch=main#fa7c98f656bc9d4549261ae9c65735e7aedec2bd"
 dependencies = [
  "anyhow",
  "anymap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "cosmicverge-shared",
  "futures-util",
  "kludgine",
+ "logger",
  "once_cell",
  "reqwest",
  "serde",
@@ -902,6 +903,7 @@ dependencies = [
  "redis",
  "serde",
  "serde_cbor",
+ "serde_json",
  "strum",
  "strum_macros",
  "thiserror",
@@ -1127,12 +1129,14 @@ name = "database"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx 0.4.0",
  "async-trait",
  "basws-server",
  "bcrypt",
  "chrono",
  "cli-table",
  "cosmicverge-shared",
+ "database",
  "dotenv",
  "either",
  "futures",
@@ -1362,7 +1366,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7ab5c993d21eb718ebf2c254ed390f483b2a8dabbda796bf342602f1689e8a"
 dependencies = [
- "flume",
+ "flume 0.7.2",
  "ignore",
  "once_cell",
  "proc-macro2",
@@ -1383,7 +1387,7 @@ dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "fluent-template-macros",
- "flume",
+ "flume 0.7.2",
  "heck",
  "ignore",
  "lazy_static",
@@ -1402,6 +1406,19 @@ checksum = "835349a364636c2aaafda82d5514c32ac7463898207ae5f97d978a82ad26b517"
 dependencies = [
  "futures",
  "spin",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a685ab99b8f60a271b44d5dd1a76e55124a8c9fa0407b7a8e9cd172d5b588"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spinning_top",
 ]
 
 [[package]]
@@ -2337,7 +2354,6 @@ dependencies = [
 [[package]]
 name = "kludgine"
 version = "0.0.2"
-source = "git+https://github.com/khonsulabs/kludgine.git?branch=main#7604b78cdf3a398a66d6470dd0ff17924b7f120b"
 dependencies = [
  "anyhow",
  "anymap",
@@ -2403,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
 
 [[package]]
 name = "libloading"
@@ -2449,6 +2465,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "logger"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "database",
+ "flume 0.10.2",
+ "futures",
+ "once_cell",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sled",
+ "strum",
+ "strum_macros",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2666,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
 dependencies = [
  "libc",
  "log",
@@ -2743,6 +2781,15 @@ dependencies = [
  "petgraph",
  "spirv_headers",
  "thiserror",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1378b66f7c93a1c0f8464a19bf47df8795083842e5090f4b7305973d5a22d0"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -3015,15 +3062,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -3035,9 +3082,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg",
  "cc",
@@ -3550,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fd1046a3107eb58f42de31d656fee6853e5d276c455fd943742dce89fc3dd3"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4011,6 +4058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spinning_top"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e529d73e80d64b5f2631f9035113347c578a1c9c7774b83a2b880788459ab36"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spirv_cross"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,9 +4299,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4398,7 +4454,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.9",
+ "mio 0.7.10",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -4508,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41768be5b9f3489491825f56f01f25290aa1d3e7cc97e182d4d34360493ba6fa"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4561,9 +4617,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -4638,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ucd-trie"
@@ -5167,9 +5223,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a921c0ad578a51c0b6c0bbb9b95f0ed11e90d61da506139e48a946edd11ee1e"
+checksum = "1e296f550993cba2c5c3eba5da0fb335562b2fa3d97b7a8ac9dc91f40a3abc70"
 dependencies = [
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ opt-level = "s"
 # basws-shared = { path = "../basws/basws-shared" }
 # sqlx-simple-migrator = { path = "../sqlx-simple-migrator" }
 # magrathea = { path = "../magrathea" }
-kludgine = { path = "../kludgine" }
+# kludgine = { path = "../kludgine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["server", "database", "migrations", "client", "web", "shared"]
+members = ["server", "database", "migrations", "client", "web", "shared", "logger"]
 
 [profile.release]
 lto = true
@@ -14,4 +14,4 @@ opt-level = "s"
 # basws-shared = { path = "../basws/basws-shared" }
 # sqlx-simple-migrator = { path = "../sqlx-simple-migrator" }
 # magrathea = { path = "../magrathea" }
-# kludgine = { path = "../kludgine" }
+kludgine = { path = "../kludgine" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["games"]
 readme = "../README.md"
 
 [dependencies]
-kludgine = { git = "https://github.com/khonsulabs/kludgine.git", branch = "main", default-features = false, features = ["tokio-rt", "bundled-fonts"] }
+kludgine = { version = "0.0.2", default-features = false, features = ["tokio-rt", "bundled-fonts"] }
 tokio = { version = "1.0", features = ["full"] }
 futures-util = "0.3"
 cosmicverge-shared = { path = "../shared" }
@@ -33,3 +33,4 @@ webbrowser = "0.5"
 async-channel = "1"
 reqwest = "0.11"
 chrono = "0.4"
+logger = { path = "../logger", default-features = false }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["games"]
 readme = "../README.md"
 
 [dependencies]
-kludgine = { version = "0.0.2", default-features = false, features = ["tokio-rt", "bundled-fonts"] }
+kludgine = { git = "https://github.com/khonsulabs/kludgine.git", branch = "main", default-features = false, features = ["tokio-rt", "bundled-fonts"] }
 tokio = { version = "1.0", features = ["full"] }
 futures-util = "0.3"
 cosmicverge-shared = { path = "../shared" }

--- a/client/src/main_window/solar_system_canvas/simulator.rs
+++ b/client/src/main_window/solar_system_canvas/simulator.rs
@@ -14,6 +14,7 @@ pub struct Simulator {
 }
 
 impl Simulator {
+    #[tracing::instrument(skip(self, ships))]
     pub fn update(
         &mut self,
         ships: Vec<navigation::Ship>,

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -43,6 +43,9 @@ tokio = "1"
 dotenv = "0.15"
 once_cell = "1"
 cli-table = "0.4"
+approx = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["sync"] }
+migrations = { path = "../migrations", features = ["test-util"] }
+database = { path = "./", features = ["test-util"] }

--- a/database/src/schema/log.rs
+++ b/database/src/schema/log.rs
@@ -27,8 +27,8 @@ impl Log {
             sqlx::query!(
                 "INSERT INTO logs (level, process, message, timestamp, payload) VALUES ($1, $2, $3, $4, $5)", 
                 entry.level as Level,
-                entry.process, 
-                entry.message, 
+                entry.process,
+                entry.message,
                 entry.timestamp,
                 entry.payload
             ).execute(&mut tx).await?;

--- a/database/src/schema/log.rs
+++ b/database/src/schema/log.rs
@@ -1,0 +1,75 @@
+use chrono::{DateTime, Utc};
+use migrations::pool;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, sqlx::Type)]
+#[sqlx(type_name = "log_level", rename_all = "lowercase")]
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Log {
+    pub level: Level,
+    pub process: String,
+    pub message: String,
+    pub timestamp: DateTime<Utc>,
+    pub payload: Option<serde_json::Value>,
+}
+
+impl Log {
+    pub async fn insert_batch(entries: &[Self]) -> sqlx::Result<()> {
+        let mut tx = pool().begin().await?;
+        for entry in entries {
+            sqlx::query!(
+                "INSERT INTO logs (level, process, message, timestamp, payload) VALUES ($1, $2, $3, $4, $5)", 
+                entry.level as Level,
+                entry.process, 
+                entry.message, 
+                entry.timestamp,
+                entry.payload
+            ).execute(&mut tx).await?;
+        }
+
+        tx.commit().await
+    }
+
+    pub async fn list_recent(count: i64) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(
+            Self,
+            "SELECT level as \"level: Level\", process, message, timestamp, payload FROM logs ORDER BY timestamp DESC LIMIT $1",
+            count
+        ).fetch_all(pool()).await
+    }
+}
+
+#[tokio::test]
+async fn test_insert_list() -> sqlx::Result<()> {
+    crate::test_util::initialize_exclusive_test().await;
+    let logs = vec![Log {
+        level: Level::Warning,
+        process: String::from("test-process"),
+        message: String::from("test-message"),
+        timestamp: Utc::now(),
+        payload: Some(serde_json::json!({"test": "value"})),
+    }];
+    Log::insert_batch(&logs).await?;
+    let from_db = Log::list_recent(10).await?;
+
+    assert_eq!(logs.len(), from_db.len());
+    assert_eq!(logs[0].level, from_db[0].level);
+    assert_eq!(logs[0].process, from_db[0].process);
+    assert_eq!(logs[0].message, from_db[0].message);
+    // This avoids the floating point error from Eq/PartialEq and the round trip
+    // from the database.
+    assert_eq!(
+        logs[0].timestamp.timestamp(),
+        from_db[0].timestamp.timestamp()
+    );
+    assert_eq!(logs[0].payload, from_db[0].payload);
+
+    Ok(())
+}

--- a/database/src/schema/mod.rs
+++ b/database/src/schema/mod.rs
@@ -1,10 +1,12 @@
 mod account;
 mod installation;
+mod log;
 mod oauth_token;
 mod permission_group;
 pub mod pilot;
 mod twitch_profile;
 
 pub use self::{
-    account::*, installation::*, oauth_token::*, permission_group::*, pilot::*, twitch_profile::*,
+    account::*, installation::*, log::*, oauth_token::*, permission_group::*, pilot::*,
+    twitch_profile::*,
 };

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "logger"
+version = "0.1.0"
+authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
+description = "Code that is shared between the client and server of Cosmic Verge"
+license = "MIT"
+repository = "https://github.com/khonsulabs/cosmicverge"
+
+publish = false
+edition = "2018"
+keywords = ["sandbox", "game"]
+categories = ["games"]
+readme = "../README.md"
+
+[features]
+default = ["archiver"]
+archiver = ["database"]
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+flume = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_cbor = "0.11"
+async-trait = "0.1.38"
+futures = "0.3"
+tokio = { version = "1", default-features = false, features = ["macros", "rt", "io-std", "io-util"] }
+anyhow = "1"
+strum = "0.20"
+strum_macros = "0.20"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+sled = "0.34"
+once_cell = "1"
+database = { path = "../database", optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", default-features = false, features = [
+    "test-util",
+    "rt",
+    "sync",
+    "macros",
+    "time",
+] }
+database = { path = "../database", features = ["test-util"] }

--- a/logger/src/backend.rs
+++ b/logger/src/backend.rs
@@ -1,0 +1,20 @@
+use std::fmt::Debug;
+
+use crate::Log;
+use async_trait::async_trait;
+
+#[cfg(feature = "archiver")]
+mod archiver;
+
+#[cfg(feature = "archiver")]
+pub use archiver::*;
+
+mod memory;
+mod os;
+
+pub use self::{memory::*, os::*};
+
+#[async_trait]
+pub trait Backend: Debug + Send + Sync {
+    async fn process_log(&mut self, log: &Log) -> anyhow::Result<()>;
+}

--- a/logger/src/backend/archiver.rs
+++ b/logger/src/backend/archiver.rs
@@ -1,0 +1,237 @@
+use std::convert::TryInto;
+
+use async_trait::async_trait;
+use flume::{bounded, Receiver, Sender};
+use futures::Future;
+use once_cell::sync::Lazy;
+use serde::Serialize;
+use sled::{transaction::TransactionError, IVec};
+
+use crate::{backend::Backend, Log};
+
+#[derive(Debug)]
+pub struct Archiver {
+    db: sled::Db,
+    archive_signal: Option<Sender<()>>,
+}
+
+#[derive(Serialize)]
+enum Key {
+    CurrentLogId,
+    LastArchivedId,
+    Log(u64),
+}
+
+static CURRENT_ID_KEY: Lazy<Vec<u8>> =
+    Lazy::new(|| serde_cbor::to_vec(&Key::CurrentLogId).unwrap());
+
+static LAST_ARCHIVED_ID_KEY: Lazy<Vec<u8>> =
+    Lazy::new(|| serde_cbor::to_vec(&Key::LastArchivedId).unwrap());
+
+impl Archiver {
+    #[must_use]
+    pub const fn new(db: sled::Db) -> Self {
+        Self {
+            db,
+            archive_signal: None,
+        }
+    }
+
+    pub fn run(&mut self) -> impl Future<Output = anyhow::Result<()>> {
+        let (sender, receiver) = bounded(1);
+        self.archive_signal = Some(sender);
+        archive_loop(receiver, self.db.clone())
+    }
+}
+
+#[async_trait]
+impl Backend for Archiver {
+    async fn process_log(&mut self, log: &Log) -> anyhow::Result<()> {
+        let tree = self.db.open_tree(b"logs")?;
+        tree.transaction::<_, _, anyhow::Error>(|tx| {
+            let current_log_id = tx
+                .get(&*CURRENT_ID_KEY)?
+                .map(convert_ivec_to_u64)
+                .unwrap_or_default();
+
+            let new_id = current_log_id.wrapping_add(1);
+            tx.insert(CURRENT_ID_KEY.clone(), new_id.to_be_bytes().to_vec())?;
+            tx.insert(
+                serde_cbor::to_vec(&Key::Log(new_id)).unwrap(),
+                serde_json::to_vec(log).unwrap(),
+            )?;
+
+            Ok(())
+        })
+        .map_transaction_error()?;
+
+        if let Some(signal) = &self.archive_signal {
+            let _ = signal.try_send(());
+        }
+
+        Ok(())
+    }
+}
+
+async fn archive_loop(signal: Receiver<()>, db: sled::Db) -> anyhow::Result<()> {
+    loop {
+        archive_logs(&db).await?;
+        signal.recv_async().await?;
+    }
+}
+
+async fn archive_logs(db: &sled::Db) -> anyhow::Result<()> {
+    let tree = db.open_tree(b"logs")?;
+
+    while matches!(archive_one_batch(&tree).await?, ArchiveStatus::LogsPending) {}
+
+    Ok(())
+}
+
+enum ArchiveStatus {
+    Archived,
+    LogsPending,
+}
+
+async fn archive_one_batch(tree: &sled::Tree) -> anyhow::Result<ArchiveStatus> {
+    // Get the current log ID for the data stored in sled. If no data is
+    // present, exit early.
+    let current_log_id = match tree.get(&*CURRENT_ID_KEY)?.map(convert_ivec_to_u64) {
+        Some(id) => id,
+        None => return Ok(ArchiveStatus::Archived),
+    };
+
+    // Loop over a range of ids to archive. This logic takes care in the
+    // event enough log messages are generated to wrap a usize. In the event
+    // of a wrap, the batch will be forced to end at at usize::MAX regardless
+    // of how small that batch ends up being. The remaining will be synced
+    // up in a second batch
+    let last_archived_id = tree
+        .get(&*LAST_ARCHIVED_ID_KEY)?
+        .map(convert_ivec_to_u64)
+        .unwrap_or_default();
+    let first_id_to_archive = last_archived_id.wrapping_add(1);
+
+    let range = if last_archived_id > current_log_id {
+        first_id_to_archive..=u64::MAX
+    } else {
+        first_id_to_archive..=current_log_id
+    };
+    if range.start() >= range.end() {
+        return Ok(ArchiveStatus::Archived);
+    }
+
+    println!(
+        "Range: {:?}, last archived {}, current {}",
+        range, last_archived_id, current_log_id
+    );
+    let mut entries_to_archive = Vec::with_capacity((range.end() - range.start()) as usize);
+    for id in range.clone() {
+        if let Some(ivec) = tree.get(&log_key_for_id(id))? {
+            match serde_json::from_slice::<Log>(&ivec) {
+                Ok(log) => {
+                    entries_to_archive.push(log);
+                }
+                Err(err) => eprintln!("Error serializing log from sled: {:?}", err),
+            }
+        }
+    }
+
+    database::schema::Log::insert_batch(
+        &entries_to_archive
+            .into_iter()
+            .map(|l| l.into())
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+
+    tree.transaction::<_, _, anyhow::Error>(|tx| {
+        for id in range.clone() {
+            tx.remove(log_key_for_id(id))?;
+        }
+
+        tx.insert(
+            LAST_ARCHIVED_ID_KEY.clone(),
+            range.end().to_be_bytes().to_vec(),
+        )?;
+
+        if current_log_id == last_archived_id {
+            Ok(ArchiveStatus::Archived)
+        } else {
+            Ok(ArchiveStatus::LogsPending)
+        }
+    })
+    .map_transaction_error()
+}
+
+trait TransactionResultExt<T> {
+    fn map_transaction_error(self) -> anyhow::Result<T>;
+}
+
+impl<T> TransactionResultExt<T> for Result<T, TransactionError<anyhow::Error>> {
+    fn map_transaction_error(self) -> anyhow::Result<T> {
+        self.map_err(|err| match err {
+            TransactionError::Abort(err) => err,
+            TransactionError::Storage(err) => anyhow::Error::from(err),
+        })
+    }
+}
+
+fn log_key_for_id(id: u64) -> Vec<u8> {
+    serde_cbor::to_vec(&Key::Log(id)).unwrap()
+}
+
+#[allow(clippy::clippy::needless_pass_by_value)] // for ergonomics of map()
+fn convert_ivec_to_u64(vec: IVec) -> u64 {
+    let array: [u8; 8] = vec.to_vec().try_into().unwrap_or_default();
+    u64::from_be_bytes(array)
+}
+
+#[tokio::test]
+async fn archiver_test() -> anyhow::Result<()> {
+    use crate::{test_util::TestMessage, Manager};
+    use std::{sync::Arc, time::Duration};
+
+    // We want to ensure our query of logs will only be the ones we insert below
+    database::test_util::initialize_exclusive_test().await;
+
+    // Create/open the sled database, and drop the logs tree if it exists already
+    let path = std::env::temp_dir().join("archiver_test.sled");
+    let db = sled::open(&path)?;
+    db.drop_tree(b"logs")?;
+    let mut test_backend = Archiver::new(db);
+    tokio::spawn(test_backend.run());
+
+    let sender = Manager::default()
+        .with_backend(test_backend)
+        .launch(|task| {
+            tokio::spawn(task);
+        });
+
+    sender.try_send(Arc::new(Log::info(TestMessage::A)))?;
+    sender.try_send(Arc::new(Log::info(TestMessage::B)))?;
+    sender.try_send(Arc::new(Log::info(TestMessage::A).with("key", "value")?))?;
+
+    // TODO I don't love hard-coding 100ms, but this one is trickier than the
+    // other tests because it involves latency to an external database. Granted,
+    // if it's localhost, a couple of ms should be plenty. For the other tests,
+    // I've been thinking of having a way to await a flush of the backends.
+    // Unfortunately for the archiver, it buffers the backend, so we still have
+    // to wait for that backend to also finish. Because of those complications,
+    // we're just waiting 100ms for now. @ecton
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // This returns entries in reverse chronology
+    let entries = database::schema::Log::list_recent(100).await?;
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].message, "A");
+    assert_eq!(
+        entries[0].payload,
+        Some(serde_json::json!({"key": "value"}))
+    );
+    assert_eq!(entries[1].message, "B");
+    assert_eq!(entries[2].message, "A");
+    assert_eq!(entries[2].payload, None);
+
+    Ok(())
+}

--- a/logger/src/backend/memory.rs
+++ b/logger/src/backend/memory.rs
@@ -1,0 +1,71 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::{backend::Backend, Log};
+
+#[derive(Debug)]
+pub struct Memory {
+    pub max_entries: usize,
+    pub entries: Arc<Mutex<VecDeque<Log>>>,
+}
+
+impl Memory {
+    #[must_use]
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries,
+            entries: Arc::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl Backend for Memory {
+    async fn process_log(&mut self, log: &Log) -> anyhow::Result<()> {
+        let mut entries = self.entries.lock().await;
+
+        entries.push_front(log.clone());
+
+        while entries.len() > self.max_entries {
+            entries.pop_back();
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::{test_util::TestMessage, Manager};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn send_test() -> anyhow::Result<()> {
+        let test_backend = Memory::new(2);
+        let entries = test_backend.entries.clone();
+        let sender = Manager::default()
+            .with_backend(test_backend)
+            .launch(|task| {
+                tokio::spawn(task);
+            });
+
+        sender.try_send(Arc::new(Log::info(TestMessage::A)))?;
+        sender.try_send(Arc::new(Log::info(TestMessage::B)))?;
+        sender.try_send(Arc::new(Log::info(TestMessage::A)))?;
+
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        {
+            let entries = entries.lock().await;
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[0].message, "A");
+            assert_eq!(entries[1].message, "B");
+        }
+
+        Ok(())
+    }
+}

--- a/logger/src/backend/os.rs
+++ b/logger/src/backend/os.rs
@@ -1,0 +1,71 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use strum::IntoEnumIterator;
+use tokio::io::{stderr, stdout, AsyncWrite, AsyncWriteExt};
+
+use crate::{Level, Pod};
+
+use super::Backend;
+
+trait AsyncWriter: AsyncWrite + Send + Sync + Debug + Unpin + 'static {}
+
+impl<T> AsyncWriter for T where T: AsyncWrite + Send + Sync + Debug + Unpin + 'static {}
+
+#[derive(Debug)]
+pub struct Os {
+    err: Box<dyn AsyncWriter>,
+    default: Box<dyn AsyncWriter>,
+    max_service_width: usize,
+}
+
+impl Os {
+    fn calculate_max_service_width() -> usize {
+        Pod::iter().map(|p| p.to_string().len()).max().unwrap()
+    }
+
+    #[must_use]
+    pub fn std() -> Self {
+        Self {
+            err: Box::new(stderr()),
+            default: Box::new(stdout()),
+            max_service_width: Self::calculate_max_service_width(),
+        }
+    }
+}
+
+#[async_trait]
+impl Backend for Os {
+    async fn process_log(&mut self, log: &crate::Log) -> anyhow::Result<()> {
+        let pipe = if log.level >= Level::Warning {
+            &mut self.err
+        } else {
+            &mut self.default
+        };
+
+        let message = format_args!(
+            "{} [{}] [{:pod_width$}]: {}\n",
+            fixed_width_level(log.level),
+            log.timestamp.to_rfc3339(),
+            log.process.to_string(),
+            log.message.to_string(),
+            pod_width = self.max_service_width,
+        )
+        .to_string();
+
+        pipe.write_all(message.as_bytes()).await?;
+        pipe.flush().await?;
+
+        Ok(())
+    }
+}
+
+const fn fixed_width_level(level: Level) -> &'static str {
+    match level {
+        Level::Trace => "TRACE",
+        Level::Debug => "DEBUG",
+        Level::Info => "INFO ",
+        Level::Warning => "WARN ",
+        Level::Error => "ERROR",
+    }
+}

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,0 +1,31 @@
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::cargo,
+    // clippy::missing_docs_in_private_items,
+    clippy::nursery,
+    clippy::pedantic,
+    future_incompatible,
+    rust_2018_idioms,
+    // missing_docs
+)]
+#![cfg_attr(doc, warn(rustdoc))]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::items_after_statements,
+    clippy::missing_errors_doc,
+    clippy::multiple_crate_versions,
+    // clippy::missing_panics_doc, // not on stable yet
+    clippy::option_if_let_else,
+)]
+
+pub mod backend;
+mod log;
+mod manager;
+pub mod tracing;
+
+pub use self::{log::*, manager::*, tracing::*};
+
+mod macros;
+#[cfg(test)]
+mod test_util;

--- a/logger/src/log.rs
+++ b/logger/src/log.rs
@@ -1,0 +1,251 @@
+use std::{fmt::Display, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use flume::Sender;
+use futures::Future;
+use once_cell::sync::OnceCell;
+use serde::{de::Error, Deserialize, Serialize};
+
+static GLOBAL_SENDER: OnceCell<Sender<Arc<Log>>> = OnceCell::new();
+
+tokio::task_local! {
+    static TASK_SENDER: Option<Sender<Arc<Log>>>;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    Debug,
+    Eq,
+    PartialEq,
+    strum_macros::EnumIter,
+    strum_macros::Display,
+)]
+pub enum Pod {
+    ClusterControl,
+    NodeControl,
+    SystemServer,
+    ApiServer,
+    Client,
+}
+
+pub trait Message: Display {
+    fn process(&self) -> Pod;
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct Log {
+    pub level: Level,
+    pub process: Pod,
+    pub message: String,
+    pub timestamp: DateTime<Utc>,
+    pub payload: serde_json::Value,
+}
+
+impl Log {
+    #[allow(clippy::clippy::needless_pass_by_value)] // This is a choice to make these APIs read cleaner, as Categories are always expected to be an enum constant.
+    pub fn new<M: Message>(level: Level, message: M) -> Self {
+        Self {
+            level,
+            process: message.process(),
+            message: message.to_string(),
+            timestamp: Utc::now(),
+            payload: serde_json::Value::Null,
+        }
+    }
+
+    pub fn error<M: Message>(message: M) -> Self {
+        Self::new(Level::Error, message)
+    }
+
+    pub fn warning<M: Message>(message: M) -> Self {
+        Self::new(Level::Warning, message)
+    }
+
+    pub fn info<M: Message>(message: M) -> Self {
+        Self::new(Level::Info, message)
+    }
+
+    pub fn debug<M: Message>(message: M) -> Self {
+        Self::new(Level::Debug, message)
+    }
+
+    pub fn trace<M: Message>(message: M) -> Self {
+        Self::new(Level::Trace, message)
+    }
+
+    pub fn add<K: Into<String>, V: Serialize>(
+        &mut self,
+        key: K,
+        value: V,
+    ) -> Result<&mut Self, serde_json::Error> {
+        if matches!(self.payload, serde_json::Value::Null) {
+            self.payload = serde_json::Value::Object(serde_json::Map::new());
+        }
+        let key = key.into();
+        if self
+            .payload
+            .as_object_mut()
+            .unwrap()
+            .insert(key, serde_json::value::to_value(value)?)
+            .is_some()
+        {
+            return Err(serde_json::Error::custom(
+                "attempting to add the same key twice",
+            ));
+        }
+
+        Ok(self)
+    }
+
+    pub fn with<K: Into<String>, V: Serialize>(
+        mut self,
+        key: K,
+        value: V,
+    ) -> Result<Self, serde_json::Error> {
+        self.add(key, value)?;
+
+        Ok(self)
+    }
+
+    pub fn submit(self) {
+        let log = Arc::new(self);
+        TASK_SENDER
+            .try_with(|sender| sender.as_ref().map(|s| s.send(log.clone())))
+            .unwrap_or_else(|_| GLOBAL_SENDER.get().as_ref().map(|sender| sender.send(log)))
+            .expect("log submitted with no backend")
+            .expect("error sending to log backend");
+    }
+
+    pub fn set_global_destination(sender: Sender<Arc<Self>>) {
+        // Uninitialize the sender in case it already was initialized
+        GLOBAL_SENDER.set(sender).unwrap();
+    }
+
+    pub async fn run_with_destination<F: Future<Output = R> + Send, R: Send>(
+        sender: Sender<Arc<Self>>,
+        future: F,
+    ) -> R {
+        TASK_SENDER.scope(Some(sender), future).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::TestMessage;
+
+    fn entries_eq_without_timestamps(a: &Log, b: &Log) -> bool {
+        a.level == b.level
+            && a.process == b.process
+            && a.message == b.message
+            && a.payload == b.payload
+    }
+
+    #[test]
+    fn entry_building_tests() -> Result<(), serde_json::Error> {
+        assert!(entries_eq_without_timestamps(
+            &Log::debug(TestMessage::A),
+            &Log {
+                level: Level::Debug,
+                process: TestMessage::A.process(),
+                message: String::from("A"),
+                payload: serde_json::Value::Null,
+                timestamp: Utc::now(),
+            }
+        ));
+
+        assert!(entries_eq_without_timestamps(
+            &Log::info(TestMessage::A),
+            &Log {
+                level: Level::Info,
+                process: TestMessage::A.process(),
+                message: String::from("A"),
+                payload: serde_json::Value::Null,
+                timestamp: Utc::now(),
+            }
+        ));
+
+        assert!(entries_eq_without_timestamps(
+            &Log::warning(TestMessage::B),
+            &Log {
+                level: Level::Warning,
+                process: TestMessage::B.process(),
+                message: String::from("B"),
+                payload: serde_json::Value::Null,
+                timestamp: Utc::now(),
+            }
+        ));
+
+        assert!(entries_eq_without_timestamps(
+            Log::error(TestMessage::B).add("key", "value")?,
+            &Log {
+                level: Level::Error,
+                process: TestMessage::B.process(),
+                message: String::from("B"),
+                payload: serde_json::json!({"key": "value"}),
+                timestamp: Utc::now(),
+            }
+        ));
+
+        assert!(entries_eq_without_timestamps(
+            Log::trace(TestMessage::B)
+                .add("key", "value")?
+                .add("key2", "value2")?,
+            &Log {
+                level: Level::Trace,
+                process: TestMessage::B.process(),
+                message: String::from("B"),
+                payload: serde_json::json!({"key": "value", "key2": "value2"}),
+                timestamp: Utc::now(),
+            }
+        ));
+
+        assert!(Log::trace(TestMessage::B)
+            .add("key", "value")?
+            .add("key", "value")
+            .is_err());
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "archiver")]
+impl Into<database::schema::Log> for Log {
+    fn into(self) -> database::schema::Log {
+        database::schema::Log {
+            level: self.level.into(),
+            process: self.process.to_string(),
+            message: self.message,
+            payload: match self.payload {
+                serde_json::Value::Null => None,
+                other => Some(other),
+            },
+            timestamp: self.timestamp,
+        }
+    }
+}
+
+#[cfg(feature = "archiver")]
+impl Into<database::schema::Level> for Level {
+    fn into(self) -> database::schema::Level {
+        match self {
+            Self::Error => database::schema::Level::Error,
+            Self::Warning => database::schema::Level::Warning,
+            Self::Info => database::schema::Level::Info,
+            Self::Debug => database::schema::Level::Debug,
+            Self::Trace => database::schema::Level::Trace,
+        }
+    }
+}

--- a/logger/src/macros.rs
+++ b/logger/src/macros.rs
@@ -1,0 +1,93 @@
+#[macro_export]
+macro_rules! log {
+    ($level:expr, $message:expr) => {
+        $crate::Log::new($level, $message).submit()
+    };
+    ($level:expr, $message:expr, $($key:expr => $value:expr),+) => {{
+        let mut log = $crate::Log::new($level, $message);
+        $(
+            log.add($key, $value).unwrap();
+        )+
+        log.submit()
+    }};
+}
+
+#[rustfmt::skip] // This macro confuses rustfmt and it tries to indent it with the inner lines very far to the right.
+macro_rules! make_level_log_macro {
+    // Passing the $ as a token is the workaround to allow parsing the repeated expression https://github.com/rust-lang/rust/issues/35853
+    ($d:tt $name:ident, $level:ident) => {
+        #[macro_export]
+        macro_rules! $name {
+            ($message:expr) => {
+                $crate::log!($crate::Level::$level, $message)
+            };
+            ($message:expr, $d($d params:tt)*) => {{
+                $crate::log!($crate::Level::$level, $message, $d($d params)*)
+            }};
+        }
+    };
+}
+
+make_level_log_macro!($ error, Error);
+make_level_log_macro!($ warn, Warning);
+make_level_log_macro!($ info, Info);
+make_level_log_macro!($ debug, Debug);
+make_level_log_macro!($ trace, Trace);
+
+#[tokio::test]
+async fn macro_tests() {
+    use crate::{backend::Memory, test_util::TestMessage, Level, Log, Manager};
+    use std::time::Duration;
+
+    let test_backend = Memory::new(2);
+    let entries = test_backend.entries.clone();
+    let destination = Manager::default()
+        .with_backend(test_backend)
+        .launch(|task| {
+            tokio::spawn(task);
+        });
+
+    let tests = async move {
+        log!(Level::Info, TestMessage::A);
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        {
+            let entries = entries.lock().await;
+            assert_eq!(entries[0].level, Level::Info);
+            assert_eq!(entries[0].message, "A");
+        }
+        log!(Level::Info, TestMessage::B, "a" => 1_u64);
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        {
+            let entries = entries.lock().await;
+            assert_eq!(entries[0].level, Level::Info);
+            assert_eq!(entries[0].payload, serde_json::json!({"a": 1_u64}));
+        }
+
+        macro_rules! test_log_level {
+            ($macroname:ident, $level:expr) => {{
+                $macroname!(TestMessage::A);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                {
+                    let entries = entries.lock().await;
+                    assert_eq!(entries[0].level, $level);
+                    assert_eq!(entries[0].message, "A");
+                }
+                $macroname!(TestMessage::B, "a" => 1_u64);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                {
+                    let entries = entries.lock().await;
+                    assert_eq!(entries[0].level, $level);
+                    assert_eq!(entries[0].payload, serde_json::json!({"a": 1_u64}));
+                }
+            }}
+        }
+
+        test_log_level!(error, Level::Error);
+        test_log_level!(warn, Level::Warning);
+        test_log_level!(info, Level::Info);
+        test_log_level!(debug, Level::Debug);
+        test_log_level!(trace, Level::Trace);
+    };
+
+    Log::run_with_destination(destination, tests).await;
+}

--- a/logger/src/manager.rs
+++ b/logger/src/manager.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use flume::{Receiver, Sender};
+use futures::{future::BoxFuture, FutureExt};
+
+use crate::{backend::Backend, Log};
+
+#[derive(Default, Debug)]
+pub struct Manager {
+    backends: Vec<Box<dyn Backend>>,
+}
+
+impl Manager {
+    pub fn with_backend<B: Backend + 'static>(mut self, backend: B) -> Self {
+        self.backends.push(Box::new(backend));
+        self
+    }
+
+    #[must_use]
+    pub fn launch<F: FnOnce(BoxFuture<'static, ()>)>(self, spawner: F) -> Sender<Arc<Log>> {
+        let (sender, receiver) = flume::unbounded();
+
+        spawner(self.run(receiver).boxed());
+
+        sender
+    }
+
+    async fn run(mut self, receiver: Receiver<Arc<Log>>) {
+        while let Ok(log) = receiver.recv_async().await {
+            futures::future::join_all(
+                self.backends
+                    .iter_mut()
+                    .map(|backend| backend.process_log(&log)),
+            )
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, anyhow::Error>>()
+            .expect("Error communicating with logging backends");
+        }
+    }
+}

--- a/logger/src/test_util.rs
+++ b/logger/src/test_util.rs
@@ -1,0 +1,13 @@
+use crate::{Message, Pod};
+
+#[derive(strum_macros::Display)]
+pub enum TestMessage {
+    A,
+    B,
+}
+
+impl Message for TestMessage {
+    fn process(&self) -> Pod {
+        Pod::SystemServer
+    }
+}

--- a/logger/src/tracing.rs
+++ b/logger/src/tracing.rs
@@ -1,0 +1,76 @@
+use std::{fmt::Display, sync::Arc};
+
+use flume::Sender;
+use tracing::{
+    field::{Field, Visit},
+    span, Subscriber,
+};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+use crate::{Level, Log, Message, Pod};
+
+pub struct Adapter {
+    pod: Pod,
+    sender: Sender<Arc<Log>>,
+}
+
+impl Adapter {
+    #[must_use]
+    pub fn new(pod: Pod, sender: Sender<Arc<Log>>) -> Self {
+        Self { pod, sender }
+    }
+}
+
+struct TracingMessage {
+    pod: Pod,
+    message: String,
+}
+
+impl Message for TracingMessage {
+    fn process(&self) -> Pod {
+        self.pod
+    }
+}
+
+impl Display for TracingMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for Adapter {
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id) {
+            let level = match *span.metadata().level() {
+                tracing::Level::DEBUG => Level::Debug,
+                tracing::Level::INFO => Level::Info,
+                tracing::Level::TRACE => Level::Trace,
+                tracing::Level::ERROR => Level::Error,
+                tracing::Level::WARN => Level::Warning,
+            };
+
+            let message = span.metadata().name().to_string();
+            let log = Log::new(
+                level,
+                TracingMessage {
+                    pod: self.pod,
+                    message,
+                },
+            );
+
+            // TODO add data from tracing
+
+            self.sender.try_send(Arc::new(log)).unwrap();
+        }
+    }
+}
+
+struct LogConverter {
+    log: Log,
+}
+
+impl Visit for LogConverter {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.log.add(field.name(), format!("{:?}", value)).unwrap();
+    }
+}

--- a/migrations/src/migrations.rs
+++ b/migrations/src/migrations.rs
@@ -5,6 +5,7 @@ use crate::connection::pool;
 mod migration_0001_accounts;
 mod migration_0002_pilots;
 mod migration_0003_permissions;
+mod migration_0004_logs;
 
 #[must_use]
 fn migrations() -> Vec<Migration> {
@@ -12,6 +13,7 @@ fn migrations() -> Vec<Migration> {
         migration_0001_accounts::migration(),
         migration_0002_pilots::migration(),
         migration_0003_permissions::migration(),
+        migration_0004_logs::migration(),
     ]
 }
 

--- a/migrations/src/migrations/migration_0004_logs.rs
+++ b/migrations/src/migrations/migration_0004_logs.rs
@@ -19,5 +19,4 @@ pub fn migration() -> Migration {
         .with_up("CREATE INDEX logs_by_timestamp ON logs(timestamp, message)")
         .with_up("CLUSTER logs USING logs_by_timestamp")
         .with_down("DROP TABLE IF EXISTS logs")
-        .debug()
 }

--- a/migrations/src/migrations/migration_0004_logs.rs
+++ b/migrations/src/migrations/migration_0004_logs.rs
@@ -1,0 +1,23 @@
+use sqlx_simple_migrator::{migration_name, Migration};
+
+pub fn migration() -> Migration {
+    Migration::new(migration_name!())
+        .with_up("CREATE TYPE log_level AS ENUM('error', 'warning', 'info', 'debug', 'trace');")
+        .with_down("DROP TYPE IF EXISTS log_level;")
+        .with_up(
+            r#"
+            CREATE TABLE logs (
+                id SERIAL PRIMARY KEY,
+                level log_level NOT NULL,
+                process TEXT NOT NULL,
+                message TEXT NOT NULL,
+                timestamp TIMESTAMPTZ NOT NULL,
+                payload JSONB NULL
+            ) WITH (FILLFACTOR=90)
+        "#,
+        )
+        .with_up("CREATE INDEX logs_by_timestamp ON logs(timestamp, message)")
+        .with_up("CLUSTER logs USING logs_by_timestamp")
+        .with_down("DROP TABLE IF EXISTS logs")
+        .debug()
+}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_cbor = "0.11"
+serde_json = "1"
 uuid = { version = "0.8", features = ["v4", "serde"] }
 basws-shared = "0.1"
 thiserror = "1"


### PR DESCRIPTION
The goals of this pull request are to:

* Add easy-to-use logging that can be persisted to postgresql, but will not slow down code executing code if psql is slow.
* Enable "structured" logging, with the goals:
  * Easily query for specific log messages (ie, don't inject parameters into the log messages)
  * Easily add type-safe data to log messages that can be queried within PostgreSQL
* Integrate with the `tracing` crate to pull in structured tracing messages